### PR TITLE
fix: Include linux/wait.h

### DIFF
--- a/pcieuni_buffer.h
+++ b/pcieuni_buffer.h
@@ -8,6 +8,7 @@
 
 #include <linux/sched.h>
 #include <linux/types.h>
+#include <linux/wait.h>
 
 struct pcieuni_dev;
 


### PR DESCRIPTION
It seems it was missing all along and either something in the kernel or
the compiler changed so that it is now causing an error
