### PR TITLE
chore: More robust version of KVERSION default

### DIFF
--- a/Makefile.kernel
+++ b/Makefile.kernel
@@ -3,7 +3,9 @@ gpcieuni-objs := gpcieuni_drv.o pcieuni_ufn.o pcieuni_probe_exp.o \
 obj-m := gpcieuni.o
 
 #build for the running kernel
-KVERSION = $(shell uname -r)
+ifndef KVERSION
+KVERSION ?= $(shell uname -r)
+endif
 
 ccflags-y = -Wall -Wuninitialized
 


### PR DESCRIPTION
Make assignment operators are confusing. The original shouldn't have
worked, but does, but perhaps sometimes doesn't?

ifndef checks if KVERSION is set and set to a non-empty string.
